### PR TITLE
rdkafka properties as directive parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,34 @@ Enables Kafka logging on the specified location. `topic`, `body` and `message_id
 
 Sets arbitrary rdkafka configuration property.
 
+### kafka_log_kafka_client_id
+* **syntax**: `kafka_log_kafka_client_id client_id`
+* **default**: `nginx`
+* **context**: `main`
+
+Sets the Kafka client id.
+
+### kafka_log_kafka_debug
+* **syntax**: `kafka_log_kafka_debug context_list`
+* **default**: `nginx`
+* **context**: `main`
+
+Sets the list of debug contexts, use comma to separate multiple values.
+
+### kafka_log_kafka_brokers
+* **syntax**: `kafka_log_kafka_brokers broker_list`
+* **default**: `nginx`
+* **context**: `main`
+
+Sets the list of bootstrap Kafka brokers, use comma to separate multiple values.
+
+### kafka_log_kafka_compression
+* **syntax**: `kafka_log_kafka_compression type`
+* **default**: `snappy`
+* **context**: `main`
+
+Sets the message compression format.
+
 ### kafka_log_kafka_partition
 * **syntax**: `kafka_log_kafka_partition id`
 * **default**: `auto`
@@ -45,11 +73,33 @@ Sets the topic partition id, the default is to automatically assign a partition 
 
 Sets the logging level of librdkafka (syslog(3) levels)
 
+### kafka_log_kafka_max_retries
+* **syntax**: `kafka_log_kafka_max_retries retries`
+* **default**: `0`
+* **context**: `main`
+
+Defines how many times to retry sending a failed MessageSet. 
+Note: retrying may cause reordering. 
+
+### kafka_log_kafka_buffer_max_messages
+* **syntax**: `kafka_log_kafka_buffer_max_messages count`
+* **default**: `100000`
+* **context**: `main`
+
+Maximum number of messages allowed on the producer queue. 
+
+### kafka_log_kafka_backoff_ms
+* **syntax**: `kafka_log_kafka_backoff_ms millis`
+* **default**: `10`
+* **context**: `main`
+
+The backoff time in milliseconds before retrying a message send. 
+
 ## Sample configuration
 ```
 http {
-	kafka_log_rdkafka_property bootstrap.servers 192.168.0.1:9092,192.168.0.2:9092;
-        kafka_log_rdkafka_property queue.buffering.max.messages 1000000;
+        kafka_log_enable on;
+	kafka_log_kafka_brokers 192.168.0.1:9092,192.168.0.2:9092;
 	
 	server {
 		location /log/ {

--- a/README.md
+++ b/README.md
@@ -24,33 +24,12 @@ In this case, the `load_module` directive should be used in nginx.conf to load t
 
 Enables Kafka logging on the specified location. `topic`, `body` and `message_id` can contain nginx variables.
 
-### kafka_log_kafka_client_id
-* **syntax**: `kafka_log_kafka_client_id client_id`
-* **default**: `nginx`
+### kafka_log_rdkafka_prop
+* **syntax**: `kafka_log_rdkafka_prop configuration.property value`
+* **default**: `n/a`
 * **context**: `main`
 
-Sets the Kafka client id.
-
-### kafka_log_kafka_debug
-* **syntax**: `kafka_log_kafka_debug context_list`
-* **default**: `nginx`
-* **context**: `main`
-
-Sets the list of debug contexts, use comma to separate multiple values.
-
-### kafka_log_kafka_brokers
-* **syntax**: `kafka_log_kafka_brokers broker_list`
-* **default**: `nginx`
-* **context**: `main`
-
-Sets the list of bootstrap Kafka brokers, use comma to separate multiple values.
-
-### kafka_log_kafka_compression
-* **syntax**: `kafka_log_kafka_compression type`
-* **default**: `snappy`
-* **context**: `main`
-
-Sets the message compression format.
+Sets arbitrary rdkafka configuration property.
 
 ### kafka_log_kafka_partition
 * **syntax**: `kafka_log_kafka_partition id`
@@ -66,32 +45,11 @@ Sets the topic partition id, the default is to automatically assign a partition 
 
 Sets the logging level of librdkafka (syslog(3) levels)
 
-### kafka_log_kafka_max_retries
-* **syntax**: `kafka_log_kafka_max_retries retries`
-* **default**: `0`
-* **context**: `main`
-
-Defines how many times to retry sending a failed MessageSet. 
-Note: retrying may cause reordering. 
-
-### kafka_log_kafka_buffer_max_messages
-* **syntax**: `kafka_log_kafka_buffer_max_messages count`
-* **default**: `100000`
-* **context**: `main`
-
-Maximum number of messages allowed on the producer queue. 
-
-### kafka_log_kafka_backoff_ms
-* **syntax**: `kafka_log_kafka_backoff_ms millis`
-* **default**: `10`
-* **context**: `main`
-
-The backoff time in milliseconds before retrying a message send. 
-
 ## Sample configuration
 ```
 http {
-	kafka_log_kafka_brokers 192.168.0.1:9092,192.168.0.2:9092;
+	kafka_log_rdkafka_property bootstrap.servers 192.168.0.1:9092,192.168.0.2:9092;
+        kafka_log_rdkafka_property queue.buffering.max.messages 1000000;
 	
 	server {
 		location /log/ {

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ In this case, the `load_module` directive should be used in nginx.conf to load t
 
 Enables Kafka logging on the specified location. `topic`, `body` and `message_id` can contain nginx variables.
 
-### kafka_log_rdkafka_prop
-* **syntax**: `kafka_log_rdkafka_prop configuration.property value`
+### kafka_log_rdkafka_property
+* **syntax**: `kafka_log_rdkafka_property configuration.property value`
 * **default**: `n/a`
 * **context**: `main`
 

--- a/ngx_http_kafka_log_module.c
+++ b/ngx_http_kafka_log_module.c
@@ -81,7 +81,7 @@ static ngx_command_t ngx_http_kafka_log_commands[] = {
         ngx_http_kafka_log_set_property,
         NGX_HTTP_MAIN_CONF_OFFSET,
         0,
-        NULL
+        "client.id"
     },
     {
         ngx_string("kafka_log_kafka_debug"),
@@ -89,7 +89,7 @@ static ngx_command_t ngx_http_kafka_log_commands[] = {
         ngx_http_kafka_log_set_property,
         NGX_HTTP_MAIN_CONF_OFFSET,
         0,
-        NULL
+        "debug"
     },
     {
         ngx_string("kafka_log_kafka_brokers"),
@@ -97,7 +97,7 @@ static ngx_command_t ngx_http_kafka_log_commands[] = {
         ngx_http_kafka_log_set_property,
         NGX_HTTP_MAIN_CONF_OFFSET,
         0,
-        NULL
+        "bootstrap.servers"
     },
     {
         ngx_string("kafka_log_kafka_compression"),
@@ -105,7 +105,7 @@ static ngx_command_t ngx_http_kafka_log_commands[] = {
         ngx_http_kafka_log_set_property,
         NGX_HTTP_MAIN_CONF_OFFSET,
         0,
-        NULL
+        "compression.codec"
     },
     {
         ngx_string("kafka_log_kafka_partition"),
@@ -121,7 +121,7 @@ static ngx_command_t ngx_http_kafka_log_commands[] = {
         ngx_http_kafka_log_set_property,
         NGX_HTTP_MAIN_CONF_OFFSET,
         0,
-        NULL
+        "log_level"
     },
     {
         ngx_string("kafka_log_kafka_max_retries"),
@@ -129,7 +129,7 @@ static ngx_command_t ngx_http_kafka_log_commands[] = {
         ngx_http_kafka_log_set_property,
         NGX_HTTP_MAIN_CONF_OFFSET,
         0,
-        NULL
+        "message.send.max.retries"
     },
     {
         ngx_string("kafka_log_kafka_buffer_max_messages"),
@@ -137,7 +137,7 @@ static ngx_command_t ngx_http_kafka_log_commands[] = {
         ngx_http_kafka_log_set_property,
         NGX_HTTP_MAIN_CONF_OFFSET,
         0,
-        NULL
+        "queue.buffering.max.messages"
     },
     {
         ngx_string("kafka_log_kafka_backoff_ms"),
@@ -145,7 +145,7 @@ static ngx_command_t ngx_http_kafka_log_commands[] = {
         ngx_http_kafka_log_set_property,
         NGX_HTTP_MAIN_CONF_OFFSET,
         0,
-        NULL
+        "retry.backoff.ms"
     },
     {
         ngx_string("kafka_log_rdkafka_property"),
@@ -409,28 +409,8 @@ ngx_http_kafka_log_set_property(ngx_conf_t *cf, ngx_command_t *cmd,
 {
     ngx_http_kafka_log_main_conf_t  *kmcf = conf;
     ngx_str_t                       *value = cf->args->elts;
-    const char                      *name = (char*)cmd->name.data;
-    char                            *prop_key, *prop_value;
-
-    if (ngx_strcmp(name, "kafka_log_kafka_client_id") == 0) {
-        prop_key = "client.id";
-    } else if (ngx_strcmp(name, "kafka_log_kafka_debug") == 0) {
-        prop_key = "debug";
-    } else if (ngx_strcmp(name, "kafka_log_kafka_brokers") == 0) {
-        prop_key = "bootstrap.servers";
-    } else if (ngx_strcmp(name, "kafka_log_kafka_compression") == 0) {
-        prop_key = "compression.codec";
-    } else if (ngx_strcmp(name, "kafka_log_kafka_max_retries") == 0) {
-        prop_key = "message.send.max.retries";
-    } else if (ngx_strcmp(name, "kafka_log_kafka_buffer_max_messages") == 0) {
-        prop_key = "queue.buffering.max.messages";
-    } else if (ngx_strcmp(name, "kafka_log_kafka_backoff_ms") == 0) {
-        prop_key = "retry.backoff.ms";
-    } else if (ngx_strcmp(name, "kafka_log_kafka_log_level") == 0) {
-        prop_key = "log_level";
-    } else {
-        return NGX_CONF_ERROR;
-    }
+    char                            *prop_key = (char*)cmd->post;
+    char                            *prop_value;
 
     prop_value = ngx_kafka_log_str_dup(cf->pool, &value[1]);
     if (!prop_value) {

--- a/ngx_kafka_log_kafka.c
+++ b/ngx_kafka_log_kafka.c
@@ -70,51 +70,6 @@ ngx_kafka_log_kafka_conf_new(ngx_pool_t *pool)
     return conf;
 }
 
-static ngx_int_t
-ngx_kafka_log_kafka_conf_set_int(
-    ngx_pool_t *pool,
-    rd_kafka_conf_t *conf,
-    const char * key,
-    ngx_int_t value)
-{
-    char buf[NGX_INT64_LEN + 1];
-    char errstr[NGX_KAFKA_LOG_KAFKA_ERROR_MSG_LEN];
-    rd_kafka_conf_res_t ret;
-
-    snprintf(buf, NGX_INT64_LEN, "%lu", value);
-    ret = rd_kafka_conf_set(conf, key, buf, errstr, sizeof(errstr));
-    if (ret != RD_KAFKA_CONF_OK) {
-        ngx_log_error(NGX_LOG_ERR, pool->log, 0,
-                "kafka_log: rd_kafka_conf_set failed [%s] => [%s] : %s", key, buf, errstr);
-        return NGX_ERROR;
-    }
-    return NGX_OK;
-}
-
-static ngx_int_t
-ngx_kafka_log_kafka_conf_set_str(
-    ngx_pool_t *pool,
-    rd_kafka_conf_t *conf,
-    const char * key,
-    ngx_str_t *str)
-{
-    char errstr[NGX_KAFKA_LOG_KAFKA_ERROR_MSG_LEN];
-
-    char *value = ngx_kafka_log_str_dup(pool, str);
-    if (!value)
-    {
-        return NGX_ERROR;
-    }
-
-    rd_kafka_conf_res_t ret = rd_kafka_conf_set(conf, key, value, errstr, sizeof(errstr));
-    if (ret != RD_KAFKA_CONF_OK) {
-        ngx_log_error(NGX_LOG_ERR, pool->log, 0,
-                "kafka_log: rd_kafka_conf_set failed [%s] => [%s] : %s", key, value, errstr);
-        return NGX_ERROR;
-    }
-    return NGX_OK;
-}
-
 static rd_kafka_conf_res_t
 ngx_kafka_log_kafka_topic_conf_set_str(
     ngx_pool_t *pool,
@@ -257,18 +212,43 @@ ngx_kafka_log_init_kafka(
     ngx_pool_t *pool,
     ngx_kafka_log_main_kafka_conf_t *kafka)
 {
-    kafka->rk                  = NULL;
-    kafka->rkc                 = NULL;
+    kafka->rk = NULL;
 
-    kafka->debug.data          = NULL;
-    kafka->brokers.data        = NULL;
-    kafka->client_id.data      = NULL;
-    kafka->compression.data    = NULL;
-    kafka->log_level           = NGX_CONF_UNSET_UINT;
-    kafka->max_retries         = NGX_CONF_UNSET_UINT;
-    kafka->buffer_max_messages = NGX_CONF_UNSET_UINT;
-    kafka->backoff_ms          = NGX_CONF_UNSET_UINT;
-    kafka->partition           = NGX_CONF_UNSET;
+    kafka->rkc = ngx_kafka_log_kafka_conf_new(pool);
+    if (! kafka->rkc) {
+        return NGX_ERROR;
+    }
+
+    return NGX_OK;
+}
+
+ngx_int_t
+ngx_kafka_log_kafka_conf_property_set(
+    ngx_pool_t *pool,
+    ngx_kafka_log_main_kafka_conf_t *conf,
+    ngx_keyval_t *prop)
+{
+    char                 errstr[NGX_KAFKA_LOG_KAFKA_ERROR_MSG_LEN];
+    char                *key, *value;
+    rd_kafka_conf_res_t  ret;
+
+    key = ngx_kafka_log_str_dup(pool, &prop->key);
+    if (!key) {
+        return NGX_ERROR;
+    }
+
+    value = ngx_kafka_log_str_dup(pool, &prop->value);
+    if (!value) {
+        return NGX_ERROR;
+    }
+
+    ret = rd_kafka_conf_set(conf->rkc, key, value, errstr, sizeof(errstr));
+    if (ret != RD_KAFKA_CONF_OK) {
+        ngx_log_error(NGX_LOG_ERR, pool->log, 0,
+                     "kafka_log: rd_kafka_conf_set failed [%s] => [%s]: %s",
+                      key, value, errstr);
+        return NGX_ERROR;
+    }
 
     return NGX_OK;
 }
@@ -276,95 +256,6 @@ ngx_kafka_log_init_kafka(
 ngx_int_t
 ngx_kafka_log_configure_kafka(ngx_pool_t *pool,
         ngx_kafka_log_main_kafka_conf_t *conf) {
-
-    /* configuration kafka constants */
-    static const char *conf_client_id_key          = "client.id";
-    static const char *conf_compression_codec_key  = "compression.codec";
-    static const char *conf_log_level_key          = "log_level";
-    static const char *conf_max_retries_key        = "message.send.max.retries";
-    static const char *conf_buffer_max_msgs_key    = "queue.buffering.max.messages";
-    static const char *conf_retry_backoff_ms_key   = "retry.backoff.ms";
-    static const char *conf_bootstrap_servers_key  = "bootstrap.servers";
-    static const char *conf_debug_key              = "debug";
-
-    /* - default values - */
-    static ngx_str_t  kafka_compression_default_value = ngx_string("snappy");
-    static ngx_str_t  kafka_client_id_default_value = ngx_string("nginx");
-    static ngx_int_t  kafka_log_level_default_value = 6;
-    static ngx_int_t  kafka_max_retries_default_value = 0;
-    static ngx_int_t  kafka_buffer_max_messages_default_value = 100000;
-    static ngx_msec_t kafka_backoff_ms_default_value = 10;
-
-    /* set default values for unset params */
-    if (conf->compression.data == NULL) {
-        conf->compression = kafka_compression_default_value;
-    }
-
-    if (conf->buffer_max_messages == NGX_CONF_UNSET_UINT) {
-        conf->buffer_max_messages = kafka_buffer_max_messages_default_value;
-    }
-
-    if (conf->max_retries == NGX_CONF_UNSET_UINT) {
-        conf->max_retries = kafka_max_retries_default_value;
-    }
-
-    if (conf->backoff_ms == NGX_CONF_UNSET_MSEC) {
-        conf->backoff_ms = kafka_backoff_ms_default_value;
-    }
-
-    if (conf->partition == NGX_CONF_UNSET) {
-        conf->partition = RD_KAFKA_PARTITION_UA;
-    }
-
-    if (conf->client_id.data == NULL) {
-        conf->client_id = kafka_client_id_default_value;
-    }
-
-    if (conf->log_level == NGX_CONF_UNSET_UINT) {
-        conf->log_level = kafka_log_level_default_value;
-    }
-
-    /* create kafka configuration */
-    conf->rkc = ngx_kafka_log_kafka_conf_new(pool);
-    if (! conf->rkc) {
-        return NGX_ERROR;
-    }
-
-    /* configure kafka */
-    ngx_kafka_log_kafka_conf_set_str(pool, conf->rkc,
-        conf_compression_codec_key,
-        &conf->compression);
-
-    ngx_kafka_log_kafka_conf_set_int(pool, conf->rkc,
-        conf_buffer_max_msgs_key,
-        conf->buffer_max_messages);
-
-    ngx_kafka_log_kafka_conf_set_int(pool, conf->rkc,
-        conf_max_retries_key,
-        conf->max_retries);
-
-    ngx_kafka_log_kafka_conf_set_int(pool, conf->rkc,
-        conf_retry_backoff_ms_key,
-        conf->backoff_ms);
-
-    ngx_kafka_log_kafka_conf_set_str(pool, conf->rkc,
-            conf_client_id_key,
-            &conf->client_id);
-
-    ngx_kafka_log_kafka_conf_set_int(pool, conf->rkc,
-        conf_log_level_key,
-        conf->log_level);
-
-    if (conf->debug.data != NULL)
-    {
-        ngx_kafka_log_kafka_conf_set_str(pool, conf->rkc,
-            conf_debug_key,
-            &conf->debug);
-    }
-
-    ngx_kafka_log_kafka_conf_set_str(pool, conf->rkc,
-            conf_bootstrap_servers_key,
-            &conf->brokers);
 
     rd_kafka_conf_set_dr_msg_cb(conf->rkc,
         ngx_kafka_log_kafka_dr_msg_cb);

--- a/ngx_kafka_log_kafka.c
+++ b/ngx_kafka_log_kafka.c
@@ -212,6 +212,17 @@ ngx_kafka_log_init_kafka(
     ngx_pool_t *pool,
     ngx_kafka_log_main_kafka_conf_t *kafka)
 {
+    size_t i;
+    const struct { char *key, *value; } defaults[] = {
+        { "compression.codec", "snappy" },
+        { "client.id", "nginx" },
+        { "message.send.max.retries", "0" },
+        { "queue.buffering.max.messages", "100000" },
+        { "retry.backoff.ms", "10" },
+        { "log_level", "6" },
+        { NULL, NULL }
+    };
+
     kafka->rk = NULL;
 
     kafka->rkc = ngx_kafka_log_kafka_conf_new(pool);
@@ -219,29 +230,11 @@ ngx_kafka_log_init_kafka(
         return NGX_ERROR;
     }
 
-    if (ngx_kafka_log_kafka_conf_property_set(pool, kafka,
-          "compression.codec", "snappy") != NGX_OK) {
-        return NGX_ERROR;
-    }
-    if (ngx_kafka_log_kafka_conf_property_set(pool, kafka,
-        "client.id", "nginx") != NGX_OK) {
-        return NGX_ERROR;
-    }
-    if (ngx_kafka_log_kafka_conf_property_set(pool, kafka,
-        "message.send.max.retries", "0") != NGX_OK) {
-        return NGX_ERROR;
-    }
-    if (ngx_kafka_log_kafka_conf_property_set(pool, kafka,
-        "queue.buffering.max.messages", "100000") != NGX_OK) {
-        return NGX_ERROR;
-    }
-    if (ngx_kafka_log_kafka_conf_property_set(pool, kafka,
-        "retry.backoff.ms", "10") != NGX_OK) {
-        return NGX_ERROR;
-    }
-    if (ngx_kafka_log_kafka_conf_property_set(pool, kafka,
-        "log_level", "6") != NGX_OK) {
-        return NGX_ERROR;
+    for (i = 0; defaults[i].key != NULL; i++) {
+        if (ngx_kafka_log_kafka_conf_property_set(pool, kafka,
+            defaults[i].key, defaults[i].value) != NGX_OK) {
+            return NGX_ERROR;
+        }
     }
 
     kafka->partition = RD_KAFKA_PARTITION_UA;

--- a/ngx_kafka_log_kafka.h
+++ b/ngx_kafka_log_kafka.h
@@ -42,14 +42,7 @@ typedef struct {
 typedef struct {
     rd_kafka_t       *rk;                  /* kafka connection handler */
     rd_kafka_conf_t  *rkc;                 /* kafka configuration */
-    ngx_str_t        debug;                /* kafka list of debug contexts */
-    ngx_str_t        brokers;              /* kafka list of brokers */
-    ngx_str_t        client_id;            /* kafka client id */
-    ngx_str_t        compression;          /* kafka communication compression */
     ngx_uint_t       log_level;            /* kafka client log level */
-    ngx_uint_t       max_retries;          /* kafka client max retries */
-    ngx_uint_t       buffer_max_messages;  /* max. num. mesg. at send buffer */
-    ngx_msec_t       backoff_ms;           /* ms to wait for ... */
     ngx_int_t        partition;            /* kafka partition */
     ngx_rbtree_t     topics_rbtree;
     ngx_rbtree_node_t topics_sentinel;
@@ -72,6 +65,11 @@ void ngx_kafka_log_kafka_topic_disable_ack(
 ngx_int_t ngx_kafka_log_init_kafka(
     ngx_pool_t *pool,
     ngx_kafka_log_main_kafka_conf_t *kafka);
+
+ngx_int_t ngx_kafka_log_kafka_conf_property_set(
+    ngx_pool_t *pool,
+    ngx_kafka_log_main_kafka_conf_t *conf,
+    ngx_keyval_t *prop);
 
 ngx_int_t ngx_kafka_log_configure_kafka(
     ngx_pool_t *pool,

--- a/ngx_kafka_log_kafka.h
+++ b/ngx_kafka_log_kafka.h
@@ -44,6 +44,7 @@ typedef struct {
     rd_kafka_conf_t  *rkc;                 /* kafka configuration */
     ngx_uint_t       log_level;            /* kafka client log level */
     ngx_int_t        partition;            /* kafka partition */
+    ngx_flag_t       enable;               /* global enable/disable */
     ngx_rbtree_t     topics_rbtree;
     ngx_rbtree_node_t topics_sentinel;
 } ngx_kafka_log_main_kafka_conf_t;

--- a/ngx_kafka_log_kafka.h
+++ b/ngx_kafka_log_kafka.h
@@ -42,7 +42,6 @@ typedef struct {
 typedef struct {
     rd_kafka_t       *rk;                  /* kafka connection handler */
     rd_kafka_conf_t  *rkc;                 /* kafka configuration */
-    ngx_uint_t       log_level;            /* kafka client log level */
     ngx_int_t        partition;            /* kafka partition */
     ngx_flag_t       enable;               /* global enable/disable */
     ngx_rbtree_t     topics_rbtree;
@@ -50,6 +49,8 @@ typedef struct {
 } ngx_kafka_log_main_kafka_conf_t;
 
 // functions
+char *ngx_kafka_log_str_dup(ngx_pool_t *pool, ngx_str_t *src);
+
 rd_kafka_topic_conf_t *ngx_kafka_log_kafka_topic_conf_new(
     ngx_pool_t* pool);
 
@@ -70,7 +71,7 @@ ngx_int_t ngx_kafka_log_init_kafka(
 ngx_int_t ngx_kafka_log_kafka_conf_property_set(
     ngx_pool_t *pool,
     ngx_kafka_log_main_kafka_conf_t *conf,
-    ngx_keyval_t *prop);
+    const char *key, const char *value);
 
 ngx_int_t ngx_kafka_log_configure_kafka(
     ngx_pool_t *pool,


### PR DESCRIPTION
Revamp configuration directives with properties parsed by rdkafka

Motivation is ability to set properties at configuration time. Currently a known set is hardcoded in configuration parsing together with string/int types (note that rdkafka property setting is always string). It will be useful to tweak various properties without a code change.

Tests:

* bad configurations fail in master process before workers are started
* print modified properties at producer-creation time with their expected values
* see requests appear as batches in Kafka log segment of a test topic
* NGINX reload applies changed rdkafka settings (and unset directives fall back to defaults)
* starts ok when module compiled but not configured
* builds and starts ok when compiled without module

Not all configuration errors are detected in master process, eg dependencies between properties like idempotence and acks. Those are flagged by rdkafka at time of producer create, at which point you get dying workers.